### PR TITLE
v1.22: fix availability gauge geometry + report preview sample data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.22 - 2026-04-16
+
+### Fixed
+
+- **Availability report gauge was drawn as a near-full circle instead of a semicircle** - `_compute_gauge_arc_path()` in `reporting/engine.py` hard-coded the SVG large-arc-flag to `1` when the percentage exceeded 50. Since the swept angle is always in `[0°, 180°]`, the large-arc-flag must stay at `0`; setting it to `1` told the renderer to "take the long way round" and traced the lower semicircle instead of the upper one. The bug was visible on every availability PDF with uptime over 50% (i.e. almost every real report). Fixed so the arc now correctly progresses from left (0%) to right (100%) along the top edge of the gauge.
+- **Admin portal report preview had its own stale copy of the gauge arc calculation** - the preview handler in `admin/views/templates.py` inlined the same buggy arc math. Replaced with a direct call to the canonical `reporting.engine._compute_gauge_arc_path()` so there is now one source of truth; the preview automatically matches what `report_generate` produces.
+- **Admin portal report preview rendered empty sections for all capacity and backup templates** - the preview handler passed legacy variable names (`cpu_data`, `memory_data`, `disk_data`, `interfaces` at top level, `backup_matrix[*].results`) that no longer match what `reporting.data_fetcher` produces at runtime. Capacity Host iterates `metrics[*].rows[*].{endpoint, avg, min, max}`, Capacity Network iterates `hosts[*].interfaces[*].{name, bandwidth_mbps, cpu_avg, cpu_min, cpu_max}` plus a top-level `cpu_rows`, Backup iterates `backup_matrix[*].statuses[day]`. Preview sample data was rewritten to mirror the real runtime shape, so the preview modal now shows fully-populated tables with colored bars (green / yellow / red thresholds) and the backup success/fail matrix with ✓/✗ symbols instead of blank sections.
+
 ## v1.21 - 2026-04-16
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ LABEL org.opencontainers.image.url="https://github.com/initMAX/zabbix-mcp-server
 LABEL org.opencontainers.image.documentation="https://github.com/initMAX/zabbix-mcp-server/blob/main/README.md"
 LABEL org.opencontainers.image.vendor="initMAX s.r.o."
 LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
-LABEL org.opencontainers.image.version="1.21"
+LABEL org.opencontainers.image.version="1.22"
 
 # System libs for weasyprint PDF rendering
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,7 +83,8 @@ We will acknowledge your report within 48 hours and work with you on a fix.
 
 | Version | Supported |
 |---|---|
-| 1.21 (latest) | Yes |
+| 1.22 (latest) | Yes |
+| 1.21 | Yes |
 | 1.20 | Yes |
 | 1.19 | Yes |
 | 1.18 | Yes |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zabbix-mcp-server"
-version = "1.21"
+version = "1.22"
 description = "Production-quality MCP server for the complete Zabbix API"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/zabbix_mcp/__init__.py
+++ b/src/zabbix_mcp/__init__.py
@@ -17,4 +17,4 @@
 
 """Zabbix MCP Server - Production-quality MCP server for the complete Zabbix API."""
 
-__version__ = "1.21"
+__version__ = "1.22"

--- a/src/zabbix_mcp/admin/views/templates.py
+++ b/src/zabbix_mcp/admin/views/templates.py
@@ -291,13 +291,14 @@ async def template_preview(request: Request) -> Response:
             loader=FileSystemLoader(str(TEMPLATE_DIR)),
         )
         template = env.from_string(html_content)
-        import math
+        # Reuse the canonical arc helper from the reporting engine so the
+        # preview matches what `report_generate` produces. The inline
+        # copy that used to live here had large-arc-flag=1 hard-coded,
+        # which drew the lower semicircle for percentage values anyway
+        # near 100%. Fixed in v1.21; keep a single source of truth.
+        from zabbix_mcp.reporting.engine import _compute_gauge_arc_path
         pct = 99.5
-        angle_deg = 180.0 - (pct / 100.0) * 180.0
-        angle_rad = math.radians(angle_deg)
-        end_x = 100.0 + 80.0 * math.cos(angle_rad)
-        end_y = 100.0 - 80.0 * math.sin(angle_rad)
-        gauge_arc = f"M 20 100 A 80 80 0 1 1 {end_x:.1f} {end_y:.1f}"
+        gauge_arc = _compute_gauge_arc_path(pct)
 
         # Use initMAX logo as preview fallback
         logo_fallback = None
@@ -307,6 +308,17 @@ async def template_preview(request: Request) -> Response:
             logo_b64 = base64.b64encode(logo_data).decode("ascii")
             logo_fallback = f"data:image/svg+xml;base64,{logo_b64}"
 
+        # Sample context for preview. The key names and nesting here
+        # must mirror what `reporting.data_fetcher` produces at runtime,
+        # otherwise the preview renders empty sections (capacity + backup
+        # reports iterate over `metrics` / `backup_matrix` with specific
+        # shapes). Kept in sync with `fetch_capacity_host_data` /
+        # `fetch_capacity_network_data` / `fetch_backup_data`.
+        sample_days = list(range(1, 32))
+        sample_statuses = {d: True for d in sample_days}
+        # Mark a few days as failed so the preview shows the red cells.
+        for d in (7, 14, 22):
+            sample_statuses[d] = False
         rendered = template.render(
             company="Sample Company",
             subtitle="IT Monitoring Service",
@@ -319,15 +331,69 @@ async def template_preview(request: Request) -> Response:
             period_from="2026-01-01",
             period_to="2026-01-31",
             period_label="01/2026",
+            # `hosts` covers availability AND capacity_network (the latter
+            # iterates host.interfaces). We attach interfaces to every
+            # host; availability.html ignores them, capacity_network.html
+            # uses them.
             hosts=[
-                {"name": "host-01", "host": "host-01", "availability_pct": 100.0, "event_count": 0},
-                {"name": "host-02", "host": "host-02", "availability_pct": 98.5, "event_count": 3},
+                {
+                    "name": "host-01", "host": "host-01",
+                    "availability_pct": 100.0, "event_count": 0,
+                    "interfaces": [
+                        {"name": "eth0", "bandwidth_mbps": 1000.0, "cpu_avg": 12.5, "cpu_min": 2.0, "cpu_max": 34.1},
+                        {"name": "eth1", "bandwidth_mbps": 100.0, "cpu_avg": 68.2, "cpu_min": 30.0, "cpu_max": 92.0},
+                    ],
+                },
+                {
+                    "name": "host-02", "host": "host-02",
+                    "availability_pct": 98.5, "event_count": 3,
+                    "interfaces": [
+                        {"name": "eth0", "bandwidth_mbps": 10000.0, "cpu_avg": 91.4, "cpu_min": 80.0, "cpu_max": 97.0},
+                    ],
+                },
             ],
-            cpu_data=[{"host": "host-01", "avg": 15.2, "min": 2.1, "max": 78.5}],
-            memory_data=[{"host": "host-01", "avg": 45.0, "min": 30.0, "max": 82.0}],
-            disk_data=[{"host": "host-01", "avg": 55.0, "min": 40.0, "max": 70.0}],
-            days=list(range(1, 31)),
-            backup_matrix=[{"host": "host-01", "results": {d: True for d in range(1, 31)}}],
+            # capacity_network.html renders `cpu_rows` as a standalone
+            # block above the per-host interface breakdown.
+            cpu_rows=[
+                {"endpoint": "host-01", "avg": 15.2, "min": 2.1, "max": 78.5},
+                {"endpoint": "host-02", "avg": 63.4, "min": 40.0, "max": 95.1},
+            ],
+            landline_count=2,
+            # capacity_host.html iterates `metrics[*].label` and each row
+            # has `endpoint/avg/min/max`. Three metrics cover the bar-color
+            # ranges (< 60 green, < 85 yellow, else red) so every color
+            # path is exercised in the preview.
+            metrics=[
+                {
+                    "label": "CPU Usage (%)",
+                    "rows": [
+                        {"endpoint": "host-01", "avg": 15.2, "min": 2.1, "max": 78.5},
+                        {"endpoint": "host-02", "avg": 63.4, "min": 40.0, "max": 95.1},
+                    ],
+                },
+                {
+                    "label": "Memory Usage (%)",
+                    "rows": [
+                        {"endpoint": "host-01", "avg": 45.0, "min": 30.0, "max": 82.0},
+                        {"endpoint": "host-02", "avg": 88.5, "min": 70.0, "max": 97.0},
+                    ],
+                },
+                {
+                    "label": "Disk Usage (%)",
+                    "rows": [
+                        {"endpoint": "host-01", "avg": 55.0, "min": 40.0, "max": 70.0},
+                        {"endpoint": "host-02", "avg": 91.0, "min": 80.0, "max": 98.0},
+                    ],
+                },
+            ],
+            # backup.html iterates days (list of ints) × backup_matrix rows.
+            # Each row is {host, statuses: {day_int: True|False|None}}.
+            days=sample_days,
+            backup_matrix=[
+                {"host": "host-01", "statuses": sample_statuses},
+                {"host": "host-02", "statuses": {d: (d % 3 != 0) for d in sample_days}},
+                {"host": "host-03", "statuses": {d: True for d in sample_days}},
+            ],
         )
         return HTMLResponse(rendered)
     except Exception as e:

--- a/src/zabbix_mcp/reporting/engine.py
+++ b/src/zabbix_mcp/reporting/engine.py
@@ -64,15 +64,22 @@ def _compute_gauge_arc_path(percentage: float) -> str:
 
     The gauge spans from 180 degrees (left) to 0 degrees (right) in a
     semicircle centered at (100, 100) with radius 80.  The *percentage*
-    value (0-100) maps linearly onto this arc.
+    value (0-100) maps linearly onto this arc, so the swept angle is
+    always between 0 and 180 degrees.
+
+    Because the swept angle never exceeds 180, the SVG large-arc-flag
+    must stay at 0: setting it to 1 when percentage > 50 (the pre-v1.21
+    behavior) told the renderer to "take the long way round", which
+    produced the lower semicircle and made a 99.5% gauge look like a
+    near-full circle. sweep-flag = 1 matches the background arc so the
+    fill progresses from left (0%) to right (100%) along the top edge.
     """
     percentage = max(0.0, min(100.0, percentage))
     angle_deg = 180.0 - (percentage / 100.0) * 180.0
     angle_rad = math.radians(angle_deg)
     end_x = 100.0 + 80.0 * math.cos(angle_rad)
     end_y = 100.0 - 80.0 * math.sin(angle_rad)
-    large_arc = 1 if percentage > 50 else 0
-    return f"M 20 100 A 80 80 0 {large_arc} 1 {end_x:.1f} {end_y:.1f}"
+    return f"M 20 100 A 80 80 0 0 1 {end_x:.1f} {end_y:.1f}"
 
 
 def _read_logo_as_base64(logo_path: str) -> str | None:


### PR DESCRIPTION
## Summary

Pure bug-fix point release. Two things regressed into v1.21:

### 1. Availability report gauge was drawn as a near-full circle

`_compute_gauge_arc_path()` in `reporting/engine.py` hard-coded the SVG large-arc-flag to \`1\` when the percentage exceeded 50. Since the swept angle is always in \`[0, 180]\`, the flag must stay at \`0\`; setting it to \`1\` made the renderer \"take the long way round\" and draw the lower semicircle instead of the upper one. Visible on every availability PDF with uptime over 50% - i.e. almost every real report.

### 2. Admin portal report preview rendered empty sections

The preview handler passed legacy variable names (\`cpu_data\`, \`memory_data\`, \`disk_data\`, flat \`interfaces\`, \`backup_matrix[*].results\`) that no longer match what \`reporting.data_fetcher\` produces at runtime. Capacity Host now iterates \`metrics[*].rows[*].{endpoint, avg, min, max}\`; Capacity Network iterates \`hosts[*].interfaces[*].{name, bandwidth_mbps, cpu_avg, cpu_min, cpu_max}\` plus a top-level \`cpu_rows\`; Backup iterates \`backup_matrix[*].statuses[day]\`. Preview sample data was rewritten to mirror the real runtime shape so all four built-in reports populate fully in the preview modal (colored bars at every threshold + backup ✓/✗ matrix).

Also consolidated the gauge math into a single source of truth: the preview now calls \`reporting.engine._compute_gauge_arc_path()\` instead of inlining its own stale copy.

## Test plan

- [x] `pytest tests/test_smoke.py tests/test_admin.py` → 285/287 pass (2 pre-existing symlink fails unrelated)
- [x] `docker compose build` + `/health` returns `{\"status\":\"ok\",\"version\":\"1.22\"}`
- [x] Gauge path test: all percentages 0-100 produce `large-arc-flag=0`
- [x] Visual Playwright regression on all 4 built-in templates: Availability gauge as proper semicircle, Capacity Host with CPU/Memory/Disk bar tables, Capacity Network with CPU + per-host interfaces tables, Backup with 3 hosts × 31 day ✓/✗ matrix