### PR TITLE
feat: add item_threshold_search extension tool

### DIFF
--- a/src/zabbix_mcp/api/extensions.py
+++ b/src/zabbix_mcp/api/extensions.py
@@ -549,3 +549,148 @@ def capacity_forecast(
     except Exception as exc:
         logger.exception("Unexpected error in capacity_forecast")
         return _error_json(f"Unexpected error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# 4. Item Threshold Search
+# ---------------------------------------------------------------------------
+
+
+def item_threshold_search(
+    client_manager: ClientManager,
+    server_name: str,
+    **kwargs: Any,
+) -> str:
+    """Search items whose current lastvalue satisfies numeric threshold conditions.
+
+    Fetches all items matching the query (via ``item.get``), then filters
+    client-side by ``lastvalue``.  Items with non-numeric lastvalues (strings,
+    empty, None) are silently skipped.  Results are sorted by lastvalue
+    descending (highest first) by default.
+
+    Use this instead of ``item_get`` + manual post-processing when you want to
+    find items above or below a threshold — e.g. "SNAT pool usage >= 50%",
+    "interface discard counter > 0", or "disk usage >= 80%".
+
+    Args:
+        client_manager: The ClientManager instance for Zabbix API access.
+        server_name: Name of the target Zabbix server.
+        **kwargs:
+            Threshold conditions (at least one recommended):
+
+            - ``lastvalue_gt`` (float): keep items where lastvalue > X.
+            - ``lastvalue_ge`` (float): keep items where lastvalue >= X.
+            - ``lastvalue_lt`` (float): keep items where lastvalue < X.
+            - ``lastvalue_le`` (float): keep items where lastvalue <= X.
+
+            Item query (all optional):
+
+            - ``search`` (dict): Zabbix substring search, e.g.
+              ``{"key_": "discards"}`` or ``{"key_": ".usage"}``.
+              Zabbix matches substrings by default, so ``"discards"`` matches
+              ``net.if.in.discards[eth0]``.  For wildcard matching, set
+              ``extra_params={"searchWildcardsEnabled": True}`` and use
+              ``{"key_": "*.usage"}``-style patterns.
+            - ``filter`` (dict): exact-match filter, e.g. ``{"type": 0}``.
+            - ``hostids`` (list[str]): restrict to these host IDs.
+            - ``groupids`` (list[str]): restrict to these host group IDs.
+            - ``output`` (str): fields to include per result item.
+              Default: ``"itemid,name,key_,lastvalue"``.  ``"extend"`` returns
+              all fields.  ``lastvalue`` is always injected when missing,
+              as it is required for threshold filtering.
+            - ``extra_params`` (dict): additional Zabbix item.get parameters,
+              e.g. ``{"selectHosts": ["host"]}`` to embed the host name.
+
+            Result control:
+
+            - ``sort_desc`` (bool): sort by lastvalue descending (default:
+              True — highest values first).
+            - ``result_limit`` (int): max matched items to return after
+              filtering and sorting.
+
+    Returns:
+        JSON string ``{"scanned": N, "matched": M, "items": [...]}``, where
+        *scanned* is the total items returned by ``item.get`` and *matched* is
+        the count after threshold filtering.  On error, returns
+        ``{"error": "..."}``.
+    """
+    try:
+        # --- Extract tool-specific parameters (not forwarded to Zabbix API) ---
+        lastvalue_gt = kwargs.get("lastvalue_gt")
+        lastvalue_ge = kwargs.get("lastvalue_ge")
+        lastvalue_lt = kwargs.get("lastvalue_lt")
+        lastvalue_le = kwargs.get("lastvalue_le")
+        sort_desc = bool(kwargs.get("sort_desc", True))
+        result_limit = kwargs.get("result_limit")
+        extra_params: dict[str, Any] = kwargs.get("extra_params") or {}
+
+        # --- Build item.get parameters ---
+        # extra_params merged first so explicit arguments take precedence on conflict
+        params: dict[str, Any] = dict(extra_params)
+
+        # Validate and normalise output; always inject lastvalue for filtering
+        output = kwargs.get("output") or "itemid,name,key_,lastvalue"
+        if output == "count":
+            return _error_json(
+                "output='count' is not supported by item_threshold_search. "
+                "The tool reports scanned/matched counts separately in its response."
+            )
+        if output != "extend":
+            fields = [f.strip() for f in output.split(",") if f.strip()]
+            if "lastvalue" not in fields:
+                fields.append("lastvalue")
+            params["output"] = fields
+        else:
+            params["output"] = output
+
+        for key in ("filter", "search", "hostids", "groupids",
+                    "searchByAny", "searchWildcardsEnabled"):
+            val = kwargs.get(key)
+            if val is not None:
+                params[key] = val
+
+        # --- Fetch all matching items ---
+        items: list[dict[str, Any]] = client_manager.call(server_name, "item.get", params)
+        scanned = len(items)
+
+        # --- Filter by lastvalue threshold conditions ---
+        matched: list[dict[str, Any]] = []
+        for item in items:
+            raw = item.get("lastvalue")
+            if raw is None or raw == "":
+                continue
+            try:
+                val = float(raw)
+            except (ValueError, TypeError):
+                continue
+
+            if lastvalue_gt is not None and not (val > float(lastvalue_gt)):
+                continue
+            if lastvalue_ge is not None and not (val >= float(lastvalue_ge)):
+                continue
+            if lastvalue_lt is not None and not (val < float(lastvalue_lt)):
+                continue
+            if lastvalue_le is not None and not (val <= float(lastvalue_le)):
+                continue
+
+            matched.append(item)
+
+        # --- Sort by lastvalue ---
+        matched.sort(
+            key=lambda x: float(x.get("lastvalue") or 0),
+            reverse=sort_desc,
+        )
+
+        # --- Apply result limit ---
+        if result_limit is not None:
+            matched = matched[: int(result_limit)]
+
+        return json.dumps({
+            "scanned": scanned,
+            "matched": len(matched),
+            "items": matched,
+        }, ensure_ascii=False)
+
+    except Exception as exc:
+        logger.exception("Unexpected error in item_threshold_search")
+        return _error_json(f"Unexpected error: {exc}")

--- a/src/zabbix_mcp/api/extensions.py
+++ b/src/zabbix_mcp/api/extensions.py
@@ -609,10 +609,11 @@ def item_threshold_search(
               filtering and sorting.
 
     Returns:
-        JSON string ``{"scanned": N, "matched": M, "items": [...]}``, where
-        *scanned* is the total items returned by ``item.get`` and *matched* is
-        the count after threshold filtering.  On error, returns
-        ``{"error": "..."}``.
+        JSON string ``{"scanned": N, "matched": M, "returned": R, "items": [...]}``,
+        where *scanned* is the total items from ``item.get``, *matched* is the
+        count passing the threshold filter, and *returned* is the number of items
+        actually included (equal to *matched* unless ``result_limit`` is set).
+        On error, returns ``{"error": "..."}``.
     """
     try:
         # --- Extract tool-specific parameters (not forwarded to Zabbix API) ---
@@ -681,13 +682,16 @@ def item_threshold_search(
             reverse=sort_desc,
         )
 
+        total_matched = len(matched)
+
         # --- Apply result limit ---
         if result_limit is not None:
             matched = matched[: int(result_limit)]
 
         return json.dumps({
             "scanned": scanned,
-            "matched": len(matched),
+            "matched": total_matched,
+            "returned": len(matched),
             "items": matched,
         }, ensure_ascii=False)
 

--- a/src/zabbix_mcp/config.py
+++ b/src/zabbix_mcp/config.py
@@ -184,6 +184,7 @@ TOOL_GROUPS: dict[str, list[str]] = {
     ],
     "extensions": [
         "graph_render", "anomaly_detect", "capacity_forecast",
+        "item_threshold_search",
         "report_generate", "action_prepare", "action_confirm",
         "zabbix_raw_api_call", "health_check",
     ],

--- a/src/zabbix_mcp/server.py
+++ b/src/zabbix_mcp/server.py
@@ -1416,7 +1416,8 @@ def _register_tools(
         - Interface discard counter above 0: search={"key_": "discards"}, lastvalue_gt=0
         - Disk usage near capacity: search={"key_": "pused"}, lastvalue_ge=80
 
-        Returns {"scanned": N, "matched": M, "items": [...]} sorted by lastvalue."""
+        Returns {"scanned": N, "matched": M, "returned": R, "items": [...]} sorted by lastvalue.
+        matched = total passing threshold; returned = items included (may be less if result_limit set)."""
         srv = client_manager.resolve_server(server or client_manager.default_server)
         _auth_err = check_token_authorization(srv, tool_prefix="item")
         if _auth_err:

--- a/src/zabbix_mcp/server.py
+++ b/src/zabbix_mcp/server.py
@@ -1304,7 +1304,7 @@ def _register_tools(
     # ------------------------------------------------------------------
     # Extension tools (server-side analytics, graph export, reporting)
     # ------------------------------------------------------------------
-    from zabbix_mcp.api.extensions import graph_render, anomaly_detect, capacity_forecast
+    from zabbix_mcp.api.extensions import graph_render, anomaly_detect, capacity_forecast, item_threshold_search
 
     async def _graph_render(
         *,
@@ -1385,6 +1385,54 @@ def _register_tools(
     if _ext_allowed("capacity_forecast"):
         mcp.add_tool(
             _capacity_forecast, name="capacity_forecast",
+            annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        )
+        count += 1
+
+    async def _item_threshold_search(
+        *,
+        lastvalue_gt: Annotated[Optional[float], Field(description="Keep only items where lastvalue > this value (strict greater-than)")] = None,
+        lastvalue_ge: Annotated[Optional[float], Field(description="Keep only items where lastvalue >= this value (e.g. 50.0 to find SNAT pools above 50% utilization)")] = None,
+        lastvalue_lt: Annotated[Optional[float], Field(description="Keep only items where lastvalue < this value (strict less-than)")] = None,
+        lastvalue_le: Annotated[Optional[float], Field(description="Keep only items where lastvalue <= this value")] = None,
+        search: Annotated[Optional[dict], Field(description="Substring search filter, e.g. {\"key_\": \"discards\"} or {\"key_\": \".usage\"}. Zabbix matches substrings — 'discards' matches 'net.if.in.discards[eth0]'")] = None,
+        filter: Annotated[Optional[dict], Field(description="Exact-match filter, e.g. {\"type\": 0} for Zabbix agent items")] = None,
+        hostids: Annotated[Optional[list[str]], Field(description="Restrict search to these host IDs")] = None,
+        groupids: Annotated[Optional[list[str]], Field(description="Restrict search to these host group IDs")] = None,
+        output: Annotated[Optional[str], Field(description="Fields to return per item: 'itemid,name,key_,lastvalue' (default) or 'extend'. lastvalue is always included for threshold filtering.")] = "itemid,name,key_,lastvalue",
+        extra_params: Annotated[Optional[dict], Field(description="Additional Zabbix item.get parameters, e.g. {\"selectHosts\": [\"host\"]} to include host name, or {\"searchWildcardsEnabled\": true} for wildcard matching")] = None,
+        sort_desc: Annotated[Optional[bool], Field(description="Sort matched items by lastvalue descending — highest values first (default: true)")] = True,
+        result_limit: Annotated[Optional[int], Field(description="Max number of matched items to return after threshold filtering")] = None,
+        server: Annotated[Optional[str], Field(description=server_desc)] = None,
+    ) -> str:
+        """Find items whose current lastvalue is above or below a numeric threshold.
+
+        Fetches all items matching the query via item.get, filters client-side
+        by lastvalue, and returns sorted results. Non-numeric lastvalues are
+        skipped. Replaces manual item_get + float(lastvalue) post-processing.
+
+        Typical uses:
+        - SNAT pool utilization above 50%: search={"key_": ".usage"}, lastvalue_ge=50
+        - Interface discard counter above 0: search={"key_": "discards"}, lastvalue_gt=0
+        - Disk usage near capacity: search={"key_": "pused"}, lastvalue_ge=80
+
+        Returns {"scanned": N, "matched": M, "items": [...]} sorted by lastvalue."""
+        srv = client_manager.resolve_server(server or client_manager.default_server)
+        _auth_err = check_token_authorization(srv, tool_prefix="item")
+        if _auth_err:
+            return json.dumps({"error": True, "message": _auth_err, "type": "AuthorizationError"})
+        return await asyncio.to_thread(
+            item_threshold_search, client_manager, srv,
+            lastvalue_gt=lastvalue_gt, lastvalue_ge=lastvalue_ge,
+            lastvalue_lt=lastvalue_lt, lastvalue_le=lastvalue_le,
+            search=search, filter=filter, hostids=hostids, groupids=groupids,
+            output=output, extra_params=extra_params,
+            sort_desc=sort_desc, result_limit=result_limit,
+        )
+
+    if _ext_allowed("item_threshold_search"):
+        mcp.add_tool(
+            _item_threshold_search, name="item_threshold_search",
             annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
         )
         count += 1

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -552,6 +552,7 @@ class TestItemThresholdSearch(unittest.TestCase):
         data = self._call(self._make_items([10.0, 50.0, 75.0, 0.0]), lastvalue_ge=50.0)
         self.assertEqual(data["scanned"], 4)
         self.assertEqual(data["matched"], 2)
+        self.assertEqual(data["returned"], 2)
         matched_vals = [float(i["lastvalue"]) for i in data["items"]]
         self.assertIn(50.0, matched_vals)
         self.assertIn(75.0, matched_vals)
@@ -559,20 +560,24 @@ class TestItemThresholdSearch(unittest.TestCase):
     def test_lastvalue_gt_excludes_equal(self):
         data = self._call(self._make_items([50.0, 50.1, 49.9]), lastvalue_gt=50.0)
         self.assertEqual(data["matched"], 1)
+        self.assertEqual(data["returned"], 1)
         self.assertEqual(float(data["items"][0]["lastvalue"]), 50.1)
 
     def test_lastvalue_le_filters_correctly(self):
         data = self._call(self._make_items([0.0, 5.0, 10.0, 100.0]), lastvalue_le=10.0)
         self.assertEqual(data["matched"], 3)
+        self.assertEqual(data["returned"], 3)
 
     def test_lastvalue_lt_excludes_equal(self):
         data = self._call(self._make_items([9.9, 10.0, 10.1]), lastvalue_lt=10.0)
         self.assertEqual(data["matched"], 1)
+        self.assertEqual(data["returned"], 1)
         self.assertEqual(float(data["items"][0]["lastvalue"]), 9.9)
 
     def test_combined_ge_and_le(self):
         data = self._call(self._make_items([20.0, 50.0, 80.0, 90.0]), lastvalue_ge=50.0, lastvalue_le=80.0)
         self.assertEqual(data["matched"], 2)
+        self.assertEqual(data["returned"], 2)
 
     def test_sorted_desc_by_default(self):
         data = self._call(self._make_items([30.0, 10.0, 70.0, 50.0]), lastvalue_gt=0)
@@ -594,6 +599,7 @@ class TestItemThresholdSearch(unittest.TestCase):
         data = self._call(items, lastvalue_ge=0)
         self.assertEqual(data["scanned"], 4)
         self.assertEqual(data["matched"], 1)
+        self.assertEqual(data["returned"], 1)
 
     def test_no_threshold_returns_all_numeric(self):
         data = self._call(self._make_items([1.0, 2.0, 3.0]))

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -487,6 +487,7 @@ class TestToolGroups(unittest.TestCase):
         from zabbix_mcp.config import TOOL_GROUPS
         ext = TOOL_GROUPS["extensions"]
         for tool in ["graph_render", "anomaly_detect", "capacity_forecast",
+                     "item_threshold_search",
                      "report_generate", "action_prepare", "action_confirm",
                      "zabbix_raw_api_call", "health_check"]:
             self.assertIn(tool, ext, f"{tool} missing from extensions group")
@@ -520,6 +521,129 @@ class TestToolGroups(unittest.TestCase):
         from zabbix_mcp.config import TOOL_GROUPS
         expected = {"monitoring", "data_collection", "alerts", "users", "administration", "extensions"}
         self.assertEqual(set(TOOL_GROUPS.keys()), expected)
+
+
+# ---------------------------------------------------------------------------
+# item_threshold_search (extensions.py)
+# ---------------------------------------------------------------------------
+class TestItemThresholdSearch(unittest.TestCase):
+    """Unit tests for the item_threshold_search extension."""
+
+    def _make_mgr(self, items):
+        """Build a minimal mock ClientManager that returns given items."""
+        from unittest.mock import MagicMock
+        mgr = MagicMock()
+        mgr.call.return_value = items
+        return mgr
+
+    def _call(self, items, **kwargs):
+        from zabbix_mcp.api.extensions import item_threshold_search
+        mgr = self._make_mgr(items)
+        result = item_threshold_search(mgr, "test", **kwargs)
+        return json.loads(result)
+
+    def _make_items(self, values):
+        return [
+            {"itemid": str(i), "name": f"item{i}", "key_": f"key{i}", "lastvalue": str(v)}
+            for i, v in enumerate(values)
+        ]
+
+    def test_lastvalue_ge_filters_correctly(self):
+        data = self._call(self._make_items([10.0, 50.0, 75.0, 0.0]), lastvalue_ge=50.0)
+        self.assertEqual(data["scanned"], 4)
+        self.assertEqual(data["matched"], 2)
+        matched_vals = [float(i["lastvalue"]) for i in data["items"]]
+        self.assertIn(50.0, matched_vals)
+        self.assertIn(75.0, matched_vals)
+
+    def test_lastvalue_gt_excludes_equal(self):
+        data = self._call(self._make_items([50.0, 50.1, 49.9]), lastvalue_gt=50.0)
+        self.assertEqual(data["matched"], 1)
+        self.assertEqual(float(data["items"][0]["lastvalue"]), 50.1)
+
+    def test_lastvalue_le_filters_correctly(self):
+        data = self._call(self._make_items([0.0, 5.0, 10.0, 100.0]), lastvalue_le=10.0)
+        self.assertEqual(data["matched"], 3)
+
+    def test_lastvalue_lt_excludes_equal(self):
+        data = self._call(self._make_items([9.9, 10.0, 10.1]), lastvalue_lt=10.0)
+        self.assertEqual(data["matched"], 1)
+        self.assertEqual(float(data["items"][0]["lastvalue"]), 9.9)
+
+    def test_combined_ge_and_le(self):
+        data = self._call(self._make_items([20.0, 50.0, 80.0, 90.0]), lastvalue_ge=50.0, lastvalue_le=80.0)
+        self.assertEqual(data["matched"], 2)
+
+    def test_sorted_desc_by_default(self):
+        data = self._call(self._make_items([30.0, 10.0, 70.0, 50.0]), lastvalue_gt=0)
+        vals = [float(i["lastvalue"]) for i in data["items"]]
+        self.assertEqual(vals, sorted(vals, reverse=True))
+
+    def test_sort_asc(self):
+        data = self._call(self._make_items([30.0, 10.0, 70.0]), lastvalue_gt=0, sort_desc=False)
+        vals = [float(i["lastvalue"]) for i in data["items"]]
+        self.assertEqual(vals, sorted(vals))
+
+    def test_non_numeric_skipped(self):
+        items = [
+            {"itemid": "1", "name": "a", "key_": "k1", "lastvalue": "N/A"},
+            {"itemid": "2", "name": "b", "key_": "k2", "lastvalue": "55.0"},
+            {"itemid": "3", "name": "c", "key_": "k3", "lastvalue": ""},
+            {"itemid": "4", "name": "d", "key_": "k4", "lastvalue": None},
+        ]
+        data = self._call(items, lastvalue_ge=0)
+        self.assertEqual(data["scanned"], 4)
+        self.assertEqual(data["matched"], 1)
+
+    def test_no_threshold_returns_all_numeric(self):
+        data = self._call(self._make_items([1.0, 2.0, 3.0]))
+        self.assertEqual(data["matched"], 3)
+
+    def test_result_limit(self):
+        data = self._call(self._make_items([10.0, 20.0, 30.0, 40.0, 50.0]),
+                          lastvalue_gt=0, result_limit=2)
+        self.assertEqual(len(data["items"]), 2)
+        self.assertEqual(data["matched"], 2)
+
+    def test_output_injects_lastvalue(self):
+        """When output omits lastvalue, it must be injected for filtering."""
+        from unittest.mock import MagicMock
+        from zabbix_mcp.api.extensions import item_threshold_search
+        mgr = MagicMock()
+        mgr.call.return_value = self._make_items([60.0])
+        item_threshold_search(mgr, "test", output="itemid,name,key_", lastvalue_ge=50.0)
+        call_params = mgr.call.call_args[0][2]
+        self.assertIn("lastvalue", call_params["output"])
+
+    def test_output_count_returns_error(self):
+        data = self._call([], output="count")
+        self.assertIn("error", data)
+
+    def test_extra_params_merged(self):
+        """extra_params forwarded to item.get (e.g. selectHosts)."""
+        from unittest.mock import MagicMock
+        from zabbix_mcp.api.extensions import item_threshold_search
+        mgr = MagicMock()
+        mgr.call.return_value = []
+        item_threshold_search(mgr, "test",
+                              extra_params={"selectHosts": ["host"]},
+                              lastvalue_ge=0)
+        call_params = mgr.call.call_args[0][2]
+        self.assertEqual(call_params.get("selectHosts"), ["host"])
+
+    def test_extra_params_do_not_override_output(self):
+        """Explicit output takes precedence over conflicting extra_params."""
+        from unittest.mock import MagicMock
+        from zabbix_mcp.api.extensions import item_threshold_search
+        mgr = MagicMock()
+        mgr.call.return_value = []
+        item_threshold_search(mgr, "test",
+                              output="itemid,name,key_,lastvalue",
+                              extra_params={"output": "extend"},
+                              lastvalue_ge=0)
+        call_params = mgr.call.call_args[0][2]
+        # explicit output should be a list (injected), not "extend"
+        self.assertIsInstance(call_params["output"], list)
 
 
 if __name__ == "__main__":

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -598,12 +598,14 @@ class TestItemThresholdSearch(unittest.TestCase):
     def test_no_threshold_returns_all_numeric(self):
         data = self._call(self._make_items([1.0, 2.0, 3.0]))
         self.assertEqual(data["matched"], 3)
+        self.assertEqual(data["returned"], 3)
 
     def test_result_limit(self):
         data = self._call(self._make_items([10.0, 20.0, 30.0, 40.0, 50.0]),
                           lastvalue_gt=0, result_limit=2)
+        self.assertEqual(data["matched"], 5)   # total passing threshold
+        self.assertEqual(data["returned"], 2)  # items actually returned
         self.assertEqual(len(data["items"]), 2)
-        self.assertEqual(data["matched"], 2)
 
     def test_output_injects_lastvalue(self):
         """When output omits lastvalue, it must be injected for filtering."""


### PR DESCRIPTION
## Problem

There is no built-in way to filter Zabbix items by their current value (lastvalue) in a single tool call. The common workaround is to call \`item_get\`, receive all matching items, and then filter client-side with code like:

\`\`\`python
items = [i for i in items if float(i.get('lastvalue') or 0) >= 50]
\`\`\`

This pattern appears repeatedly in real-world usage (SRE automation, AI agent skill files) for cases such as:
- Find all SNAT pool items with utilisation ≥ 50%
- Find all network interfaces with discard counters > 0
- Find all disks with usage ≥ 80%

Because Zabbix's \`item.get\` API does not support server-side filtering by \`lastvalue\`, the post-processing must happen somewhere. This PR moves that responsibility into a dedicated MCP tool so agents and automation scripts don't have to implement it themselves.

## Solution

Adds a new extension tool \`item_threshold_search\` that:

1. Calls \`item.get\` with the provided query parameters (\`search\`, \`filter\`, \`hostids\`, \`groupids\`, \`extra_params\`, \`output\`)
2. Filters results client-side using one or more numeric threshold conditions: \`lastvalue_gt\`, \`lastvalue_ge\`, \`lastvalue_lt\`, \`lastvalue_le\`
3. Skips items with non-numeric \`lastvalue\` (strings, empty, None) silently
4. Returns \`{"scanned": N, "matched": M, "returned": R, "items": [...]}\` sorted by \`lastvalue\` descending (highest first by default)
   - \`matched\`: total items passing the threshold filter
   - \`returned\`: items actually included (≤ matched when \`result_limit\` is set)

\`lastvalue\` is always injected into the \`output\` field list when missing, so filtering works regardless of what the caller requested.

## Example usage

\`\`\`
# SNAT pool utilisation above 50%
item_threshold_search
  search: {"key_": ".usage"}
  lastvalue_ge: 50
  extra_params: {"selectHosts": ["host"]}

# Interface discard counters above 0
item_threshold_search
  search: {"key_": "discards"}
  lastvalue_gt: 0
  output: "itemid,name,key_,lastvalue"
  extra_params: {"selectHosts": ["host"]}
\`\`\`

## Changes

- \`src/zabbix_mcp/api/extensions.py\`: adds \`item_threshold_search()\` function (section 4)
- \`src/zabbix_mcp/server.py\`: adds \`_item_threshold_search\` wrapper and \`mcp.add_tool()\` registration
- \`src/zabbix_mcp/config.py\`: adds \`"item_threshold_search"\` to \`TOOL_GROUPS["extensions"]\`
- \`tests/test_admin.py\`: adds 14 unit tests covering threshold conditions, sort order, non-numeric skip, output injection, result_limit, and extra_params precedence

## Test plan

- [x] \`python3 -m pytest tests/test_admin.py -k ItemThreshold\` — 14 tests pass
- [x] \`python3 -m pytest tests/\` — 299 tests pass (2 pre-existing symlink failures unrelated to this PR)
- [x] \`python3 -m py_compile\` on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)