### PR TITLE
feat: support username/password auth for Zabbix < 5.4

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ Two ways to deploy the Zabbix MCP Server: **on-prem** (systemd service) or **Doc
 Both methods require:
 
 - Network access to your Zabbix server(s)
-- A [Zabbix API token](https://www.zabbix.com/documentation/current/en/manual/web_interface/frontend_sections/users/api_tokens) (created in Zabbix frontend: **Users → API tokens → Create API token**)
+- A Zabbix account to authenticate with: either an [API token](https://www.zabbix.com/documentation/current/en/manual/web_interface/frontend_sections/users/api_tokens) (Zabbix 5.4+, created in the frontend: **Users → API tokens → Create API token**) **or** a username + password (Zabbix 5.0 – 5.2, which has no API tokens)
 
 ## Option 1: On-Prem Installation (systemd)
 
@@ -52,7 +52,7 @@ The installer will:
 sudo nano /etc/zabbix-mcp/config.toml
 ```
 
-Minimal configuration — fill in your Zabbix URL and API token:
+Minimal configuration — fill in your Zabbix URL and API token (or, on Zabbix 5.0 – 5.2 which has no API tokens, `username` + `password`):
 
 ```toml
 [server]
@@ -63,6 +63,9 @@ port = 8080
 [zabbix.production]
 url = "https://zabbix.example.com"
 api_token = "your-zabbix-api-token-here"
+# Zabbix < 5.4: use username + password instead of api_token
+# username = "zabbix-mcp"
+# password = "${ZABBIX_PROD_PASSWORD}"
 read_only = true
 ```
 
@@ -173,6 +176,9 @@ transport = "http"
 [zabbix.production]
 url = "https://zabbix.example.com"
 api_token = "your-zabbix-api-token-here"
+# Zabbix < 5.4: use username + password instead of api_token
+# username = "zabbix-mcp"
+# password = "${ZABBIX_PROD_PASSWORD}"
 read_only = true
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Done. The server is running on `http://127.0.0.1:8080/mcp`.
 
 - Linux server with Python 3.10+
 - Network access to your Zabbix server(s)
-- Zabbix API token ([User settings > API tokens](https://www.zabbix.com/documentation/current/en/manual/web_interface/frontend_sections/users/api_tokens))
+- A Zabbix account to authenticate with: an **API token** ([User settings > API tokens](https://www.zabbix.com/documentation/current/en/manual/web_interface/frontend_sections/users/api_tokens), Zabbix 5.4+) or **username + password** (Zabbix 5.0 – 5.2, which has no API tokens)
 
 ### Install
 
@@ -193,6 +193,10 @@ url = "https://zabbix.example.com"
 api_token = "your-api-token"
 read_only = true
 verify_ssl = true
+
+# Zabbix 5.0 – 5.2 has no API tokens: use username + password instead:
+# username = "zabbix-mcp"
+# password = "${ZABBIX_PROD_PASSWORD}"
 ```
 
 All available options with detailed descriptions are documented in [`config.example.toml`](config.example.toml).
@@ -211,7 +215,7 @@ The config file contains **two different types of tokens** that serve different 
                                     └──────────────────┘
 ```
 
-**`api_token`** (in `[zabbix.*]`) — **required** — authenticates the MCP server to your Zabbix instance. This is a [Zabbix API token](https://www.zabbix.com/documentation/current/en/manual/web_interface/frontend_sections/users/api_tokens) that you create in the Zabbix frontend.
+**`api_token`** (in `[zabbix.*]`) — authenticates the MCP server to your Zabbix instance. This is a [Zabbix API token](https://www.zabbix.com/documentation/current/en/manual/web_interface/frontend_sections/users/api_tokens) that you create in the Zabbix frontend. It is **required** unless you authenticate with `username`/`password` instead — see [Zabbix 5.0 and older](#zabbix-50-and-older-no-api-tokens) below.
 
 How to create one:
 
@@ -229,6 +233,41 @@ The token inherits the permissions of the Zabbix user it belongs to:
 | Complete API access (users, settings, global scripts) | **Super admin** role | `false` |
 
 Use the principle of least privilege — create a dedicated Zabbix user for the MCP server with only the permissions it needs.
+
+#### Zabbix 5.0 and older (no API tokens)
+
+Zabbix only introduced API tokens in **5.4**. On Zabbix **5.0 – 5.2**, authenticate with `username`/`password` instead — the MCP server calls `user.login` on every connection:
+
+```toml
+[zabbix.production]
+url = "https://zabbix.example.com"
+username = "zabbix-mcp"          # dedicated low-privilege account
+password = "${ZABBIX_PROD_PASSWORD}"
+read_only = true
+```
+
+`api_token` takes precedence when both are set. The same least-privilege rule applies: use a dedicated Zabbix user with only the permissions the MCP tools need.
+
+**Keeping the password out of the config file:** `username` and `password` support `${ENV_VAR}` expansion, so you can store the secret in an environment variable instead of plaintext in `config.toml`. Under Docker, add the variable to your `.env` file (the compose file injects it via `env_file`):
+
+```bash
+# .env
+ZABBIX_PROD_USER=zabbix-mcp
+ZABBIX_PROD_PASSWORD=your-password-here
+```
+
+```toml
+# config.toml
+[zabbix.production]
+url = "https://zabbix.example.com"
+username = "${ZABBIX_PROD_USER}"
+password = "${ZABBIX_PROD_PASSWORD}"
+read_only = true
+```
+
+The variable name is up to you (`ZBX_PASSWORD`, `ZABBIX_PASSWORD`, ...) as long as the `${...}` reference in TOML matches the variable in the environment of the running process/container.
+
+> **Zabbix 5.0 note:** the underlying `zabbix-utils` library only supports Zabbix ≥ 6.0 by default. The MCP server automatically skips the version compatibility check whenever it authenticates with `username`/`password`, so no extra config is needed on Zabbix 5.0.
 
 #### MCP Authentication (optional)
 
@@ -293,7 +332,8 @@ read_only = true
 
 [zabbix.staging]
 url = "https://zabbix-staging.example.com"
-api_token = "staging-token"
+username = "zabbix-mcp"
+password = "${ZABBIX_STAGING_PASSWORD}"
 read_only = false
 ```
 
@@ -1024,8 +1064,9 @@ All available options with detailed descriptions are in [`config.example.toml`](
 <tr><td><code>allowed_import_dirs</code></td><td>Directories for <code>source_file</code> imports (default: disabled)</td></tr>
 <tr><td><code>compact_output</code></td><td>Return only key fields from get methods (default: <code>true</code>); set to <code>false</code> to always return all fields</td></tr>
 <tr><td><code>response_max_chars</code></td><td>Maximum characters per tool response before truncation (default: <code>50000</code>, min: <code>5000</code>). Increase for template export workflows: <code>200000</code> for medium templates, <code>500000</code> for large built-in templates. See <a href="#token-budget">Token Budget</a></td></tr>
-<tr><td rowspan="5"><code>[zabbix.&lt;name&gt;]</code></td><td><code>url</code></td><td>Zabbix frontend URL (must start with <code>http://</code> or <code>https://</code>)</td></tr>
-<tr><td><code>api_token</code></td><td>API token (supports <code>${ENV_VAR}</code>)</td></tr>
+<tr><td rowspan="6"><code>[zabbix.&lt;name&gt;]</code></td><td><code>url</code></td><td>Zabbix frontend URL (must start with <code>http://</code> or <code>https://</code>)</td></tr>
+<tr><td><code>api_token</code></td><td>API token (supports <code>${ENV_VAR}</code>) — required unless <code>username</code>/<code>password</code> is set (Zabbix &lt; 5.4)</td></tr>
+<tr><td><code>username</code> / <code>password</code></td><td>Zabbix login credentials for versions without API tokens (Zabbix 5.0 – 5.2); the server calls <code>user.login</code>. Only used when <code>api_token</code> is empty</td></tr>
 <tr><td><code>read_only</code></td><td>Block write operations (default: <code>true</code>)</td></tr>
 <tr><td><code>verify_ssl</code></td><td>Verify TLS certificates (default: <code>true</code>)</td></tr>
 <tr><td><code>skip_version_check</code></td><td>Skip zabbix-utils version compatibility check (default: <code>false</code>)</td></tr>

--- a/config.example.toml
+++ b/config.example.toml
@@ -597,10 +597,18 @@ update_check_enabled = true
 # The /api_jsonrpc.php path is added automatically by the API client.
 url = "https://zabbix.example.com"
 
-# Zabbix API token for authentication (REQUIRED).
-# This authenticates the MCP server to Zabbix — NOT the same as auth_token above.
-# Create one in Zabbix: User settings > API tokens > Create API token.
-# Tokens inherit the permissions of the Zabbix user they belong to.
+# Zabbix API token for authentication. This authenticates the MCP server
+# to Zabbix — NOT the same as auth_token above. Create one in Zabbix 5.4+:
+# User settings > API tokens > Create API token. Tokens inherit the
+# permissions of the Zabbix user they belong to.
+#
+# Either `api_token` OR `username` + `password` must be set. Zabbix 5.0-5.2
+# do NOT support API tokens, so use the username/password pair there:
+#
+#   username = "zabbix-mcp"
+#   password = "${ZABBIX_PROD_PASSWORD}"
+#
+# When api_token is present it takes precedence over username/password.
 api_token = "your-api-token-here"
 
 # You can reference an environment variable instead of storing the token in plain text:
@@ -644,6 +652,9 @@ verify_ssl = true
 # [zabbix.staging]
 # url = "https://zabbix-staging.example.com"
 # api_token = "${ZABBIX_STAGING_TOKEN}"
+# ... or, for Zabbix 5.0-5.2 (no API tokens), use login credentials instead:
+# username = "zabbix-mcp"
+# password = "${ZABBIX_STAGING_PASSWORD}"
 # read_only = false
 # verify_ssl = false
 # skip_version_check = false

--- a/src/zabbix_mcp/admin/app.py
+++ b/src/zabbix_mcp/admin/app.py
@@ -683,7 +683,7 @@ class AdminApp:
                 if result.get("token_ok"):
                     results[name] = {"status": "online", "version": version}
                 else:
-                    results[name] = {"status": "token_error", "version": version, "error": "API online but token invalid or expired"}
+                    results[name] = {"status": "token_error", "version": version, "error": "API online but authentication failed (invalid token or credentials)"}
             except Exception as e:
                 results[name] = {"status": "error", "error": str(e)[:100]}
         # Sections skipped at config load: report the validation error

--- a/src/zabbix_mcp/admin/templates/servers.html
+++ b/src/zabbix_mcp/admin/templates/servers.html
@@ -42,9 +42,17 @@
             <input type="url" name="url" class="form-input" placeholder="https://zabbix.example.com" required value="{{ form_url | default('') }}">
         </div>
         <div class="form-group">
-            <label class="form-label">API Token <span class="tooltip-icon" tabindex="0" data-tooltip="Zabbix API token (User settings -> API tokens in the Zabbix UI). Must have permissions for the actions the AI client will perform.">&#x1F6C8;</span></label>
-            <input type="text" name="api_token" class="form-input" placeholder="Zabbix API token" required value="{{ form_api_token | default('') }}">
-            <small class="text-muted">Create in Zabbix: User settings &rarr; API tokens</small>
+            <label class="form-label">API Token <span class="tooltip-icon" tabindex="0" data-tooltip="Zabbix API token (User settings -> API tokens in the Zabbix UI). Must have permissions for the actions the AI client will perform. Zabbix 5.4+ only - for older versions use the username/password fields below instead.">&#x1F6C8;</span></label>
+            <input type="text" name="api_token" class="form-input" placeholder="Zabbix API token" value="{{ form_api_token | default('') }}">
+            <small class="text-muted">Create in Zabbix: User settings &rarr; API tokens. Leave empty when using username/password below (Zabbix &lt; 5.4).</small>
+        </div>
+        <div class="form-group">
+            <label class="form-label">Username <span class="tooltip-icon" tabindex="0" data-tooltip="Zabbix user for servers without API tokens (Zabbix < 5.4). The MCP server logs in with user.login. Ignored when an API token is set.">&#x1F6C8;</span></label>
+            <input type="text" name="username" class="form-input" placeholder="e.g. zabbix-api" value="{{ form_username | default('') }}" autocomplete="off">
+        </div>
+        <div class="form-group">
+            <label class="form-label">Password <span class="tooltip-icon" tabindex="0" data-tooltip="Password for the username above. Required when no API token is set.">&#x1F6C8;</span></label>
+            <input type="password" name="password" class="form-input" placeholder="Password" value="{{ form_password | default('') }}" autocomplete="new-password">
         </div>
         <div class="form-group" style="display:flex; gap:24px;">
             <label style="display:flex; align-items:center; gap:8px; cursor:pointer;" tabindex="0" data-tooltip="When checked, MCP tools that mutate Zabbix data (host_create, item_update, ...) are blocked at the server level. Recommended for production: leave checked and grant per-token write scope only when needed.">
@@ -90,7 +98,7 @@
             _setTestResult(container, 'status-dot-green', 'Connected' + (ver ? ' — Zabbix ' + ver : ''));
             return true;
         } else if (doc.querySelector('.status-dot-yellow')) {
-            _setTestResult(container, 'status-dot-yellow', 'API online — Token invalid or expired');
+            _setTestResult(container, 'status-dot-yellow', 'API online — Invalid credentials');
             return false;
         } else if (doc.querySelector('.status-dot-red')) {
             var errSpan = doc.querySelector('span[style*="color:var(--color-danger)"]');
@@ -115,6 +123,8 @@
         }
         var url = form.querySelector('[name=url]').value;
         var token = form.querySelector('[name=api_token]').value;
+        var username = form.querySelector('[name=username]').value;
+        var password = form.querySelector('[name=password]').value;
         var ssl = form.querySelector('[name=verify_ssl]').checked;
         var result = document.getElementById('add-test-result');
         var btn = document.getElementById('add-save-btn');
@@ -126,7 +136,11 @@
         fetch('/servers/test-new', {
             method: 'POST',
             headers: _headers,
-            body: 'url=' + encodeURIComponent(url) + '&api_token=' + encodeURIComponent(token) + '&verify_ssl=' + (ssl ? '1' : '0'),
+            body: 'url=' + encodeURIComponent(url)
+                + '&api_token=' + encodeURIComponent(token)
+                + '&username=' + encodeURIComponent(username)
+                + '&password=' + encodeURIComponent(password)
+                + '&verify_ssl=' + (ssl ? '1' : '0'),
         })
         .then(function(r) { return r.text(); })
         .then(function(html) {

--- a/src/zabbix_mcp/admin/templates/servers_edit.html
+++ b/src/zabbix_mcp/admin/templates/servers_edit.html
@@ -32,9 +32,29 @@
             <input type="url" name="url" id="srv-url" class="form-input" value="{{ server.url | default('') }}" required>
         </div>
         <div class="form-group">
-            <label class="form-label">API Token <span class="tooltip-icon" tabindex="0" data-tooltip="Zabbix API token (User settings -> API tokens in Zabbix UI). Must have permissions for the actions the AI client will perform. Leave empty here to keep the current value.">&#x1F6C8;</span></label>
+            <label class="form-label">API Token <span class="tooltip-icon" tabindex="0" data-tooltip="Zabbix API token (User settings -> API tokens in Zabbix UI). Must have permissions for the actions the AI client will perform. Zabbix 5.4+ only - for older versions use the username/password fields below instead. Leave empty here to keep the current value.">&#x1F6C8;</span></label>
             <input type="password" name="api_token" id="srv-token" class="form-input" value="" placeholder="Leave empty to keep current" autocomplete="off">
-            <small class="text-muted">Leave empty to keep the current token. Current: <code>{{ server.api_token[:8] }}...{{ server.api_token[-4:] }}</code></small>
+            <small class="text-muted">
+                {% if server.api_token %}
+                Leave empty to keep the current token. Current: <code>{{ server.api_token[:8] }}...{{ server.api_token[-4:] }}</code>
+                {% else %}
+                No API token configured for this server &mdash; authentication uses the username/password below.
+                {% endif %}
+            </small>
+        </div>
+        <div class="form-group">
+            <label class="form-label">Username <span class="tooltip-icon" tabindex="0" data-tooltip="Zabbix user for servers without API tokens (Zabbix < 5.4). The MCP server logs in with user.login. Ignored when an API token is set. Leave empty to clear the stored username (also clears the password).">&#x1F6C8;</span></label>
+            <input type="text" name="username" id="srv-user" class="form-input" value="{{ server.username | default('') }}" autocomplete="off" placeholder="e.g. zabbix-api">
+            <small class="text-muted">Used when no API token is set. Leave empty to clear it (and the stored password).</small>
+        </div>
+        <div class="form-group">
+            <label class="form-label">Password <span class="tooltip-icon" tabindex="0" data-tooltip="Password for the username above. Leave empty to keep the current value. To remove it, clear the username field above.">&#x1F6C8;</span></label>
+            <input type="password" name="password" id="srv-pass" class="form-input" value="" placeholder="{% if server.password %}Leave empty to keep current{% else %}Not configured{% endif %}" autocomplete="new-password">
+            <small class="text-muted">
+                {% if server.password %}Password is set. Leave empty to keep it; type a new value to replace it. Use <code>${ENV_VAR}</code> to reference an environment variable.
+                {% else %}Not configured. Required unless an API token is set.
+                {% endif %}
+            </small>
         </div>
         <div class="form-group" style="display:flex; gap:24px;">
             <label style="display:flex; align-items:center; gap:8px; cursor:pointer;" tabindex="0" data-tooltip="When checked, MCP tools that mutate Zabbix data (host_create, item_update, ...) are blocked at the server level. Recommended for production: leave checked and grant per-token write scope only when needed.">
@@ -113,7 +133,7 @@ function _parseTestResponse(container, responseText) {
         var ver = versionMatch ? versionMatch[1] : '';
         _setTestResult(container, 'status-dot-green', 'Connected' + (ver ? ' — Zabbix ' + ver : ''));
     } else if (yellowDot) {
-        _setTestResult(container, 'status-dot-yellow', 'API online — Token invalid or expired');
+        _setTestResult(container, 'status-dot-yellow', 'API online — Invalid credentials');
     } else if (redDot) {
         var errSpan = doc.querySelector('span[style*="color:var(--color-danger)"]');
         var msg = errSpan ? errSpan.textContent.trim() : doc.body.textContent.trim();
@@ -138,14 +158,16 @@ function _csrfHeader() {
 function testEditServer() {
     var url = document.getElementById('srv-url').value;
     var token = document.getElementById('srv-token').value;
+    var username = document.getElementById('srv-user').value;
+    var password = document.getElementById('srv-pass').value;
     var ssl = document.getElementById('srv-ssl').checked;
     var result = document.getElementById('edit-test-result');
     _setTestResult(result, '', 'Testing...');
 
     var csrf = _csrfHeader();
 
-    // If token is empty, we can't test with a new token — test existing connection
-    if (!token) {
+    // Nothing new typed — test the existing saved connection.
+    if (!token && !username && !password) {
         fetch('/servers/{{ edit_server_name }}/test', {method: 'POST', headers: csrf})
             .then(function(r) { return r.text(); })
             .then(function(html) { _parseTestResponse(result, html); })
@@ -156,7 +178,11 @@ function testEditServer() {
     fetch('/servers/test-new', {
         method: 'POST',
         headers: Object.assign({'Content-Type': 'application/x-www-form-urlencoded'}, csrf),
-        body: 'url=' + encodeURIComponent(url) + '&api_token=' + encodeURIComponent(token) + '&verify_ssl=' + (ssl ? '1' : '0'),
+        body: 'url=' + encodeURIComponent(url)
+            + '&api_token=' + encodeURIComponent(token)
+            + '&username=' + encodeURIComponent(username)
+            + '&password=' + encodeURIComponent(password)
+            + '&verify_ssl=' + (ssl ? '1' : '0'),
     })
     .then(function(r) { return r.text(); })
     .then(function(html) { _parseTestResponse(result, html); })

--- a/src/zabbix_mcp/admin/views/servers.py
+++ b/src/zabbix_mcp/admin/views/servers.py
@@ -193,6 +193,11 @@ async def server_create(request: Request) -> Response:
     # what stops the mismatch existing at all.
     url = _normalize_url(str(form.get("url", "")).strip())
     api_token = str(form.get("api_token", "")).strip()
+    # Zabbix < 5.4 has no API tokens — username/password is the
+    # alternative. `password` may stay empty on create (nothing to keep);
+    # it is only stored when the operator typed something.
+    username = str(form.get("username", "")).strip()
+    password = str(form.get("password", "")).strip()
     read_only = "read_only" in form
     verify_ssl = "verify_ssl" in form
     request_timeout = _parse_timeout(form.get("request_timeout"))
@@ -207,6 +212,8 @@ async def server_create(request: Request) -> Response:
             "form_name": name,
             "form_url": url,
             "form_api_token": api_token,
+            "form_username": username,
+            "form_password": password,
             "form_read_only": read_only,
             "form_verify_ssl": verify_ssl,
         })
@@ -231,6 +238,13 @@ async def server_create(request: Request) -> Response:
     except Exception as exc:
         return _err(f"Invalid URL: {exc}")
 
+    # Auth method: Zabbix < 5.4 has no API tokens, so username/password
+    # is the fallback (mirrors _parse_zabbix_server in config.py). At
+    # least one method must be provided; if the operator picked
+    # username/password, both fields are required.
+    if not api_token and (not username or not password):
+        return _err("Provide an API token, or a username and password pair (Zabbix < 5.4 has no API tokens).")
+
     # Explicit duplicate-name check before tomlkit raises
     # `KeyAlreadyPresent: Key "<name>" already exists.` and we have to
     # reformat its internal "Key" wording into a user-facing
@@ -251,6 +265,13 @@ async def server_create(request: Request) -> Response:
             "verify_ssl": verify_ssl,
             "request_timeout": request_timeout,
         }
+        # Persist username/password only when filled. Empty password on a
+        # fresh server means the operator left the field blank (nothing to
+        # keep yet), so we simply do not write it.
+        if username:
+            server_data["username"] = username
+        if password:
+            server_data["password"] = password
         add_config_table(admin_app.config_path, "zabbix", name, server_data)
         logger.info("Zabbix server '%s' added by %s", name, session.user)
         client_ip = request.client.host if request.client else ""
@@ -315,6 +336,12 @@ async def server_edit(request: Request) -> Response:
     new_name = str(form.get("name", "")).strip()
     url = _normalize_url(str(form.get("url", "")).strip())
     api_token = str(form.get("api_token", "")).strip()
+    # Zabbix < 5.4 auth. username follows the same "text field, blank =
+    # clear" rule as frontend_username; password follows the "leave empty
+    # to keep" rule as frontend_password / api_token. Clearing the
+    # username also drops the stored password so no orphan secret lingers.
+    username = str(form.get("username", "")).strip()
+    password = str(form.get("password", "")).strip()
     read_only = "read_only" in form
     verify_ssl = "verify_ssl" in form
     request_timeout = _parse_timeout(form.get("request_timeout"))
@@ -368,6 +395,16 @@ async def server_edit(request: Request) -> Response:
             # User cleared username -> also drop password to avoid
             # orphan secret stored without a matching username.
             zabbix[server_name].pop("frontend_password", None)
+
+        # Zabbix API auth: username is a plaintext field that always
+        # writes (blank = clear). password only overwrites when the
+        # operator typed a new value; clearing the username also removes
+        # the stored password so a secret never lingers without its user.
+        zabbix[server_name]["username"] = username
+        if password:
+            zabbix[server_name]["password"] = password
+        elif not username:
+            zabbix[server_name].pop("password", None)
 
         if renamed:
             # tomlkit has no rename — copy the table data into a new entry
@@ -467,7 +504,7 @@ def _friendly_error(exc: Exception) -> str:
     if "ssl" in lower or "certificate" in lower:
         return "TLS handshake failed. Check the certificate or set verify_ssl = false in config.toml."
     if "401" in msg or "unauthorized" in lower:
-        return "Zabbix returned 401. The API token is invalid or expired."
+        return "Zabbix returned 401. The API token or username/password is invalid or expired."
     if "403" in msg or "forbidden" in lower:
         # Cloudflare / generic WAF in front of the Zabbix frontend
         # randomly returns 403 to direct JSON-RPC POSTs (no browser
@@ -491,6 +528,29 @@ def _friendly_error(exc: Exception) -> str:
     return msg
 
 
+def _probe_user_login(url: str, username: str, password: str, verify_ssl: bool) -> tuple[bool, str]:
+    """Probe a Zabbix server using username/password auth (Zabbix < 5.4).
+
+    Returns ``(auth_ok, version)``: ``auth_ok`` is False when the API is
+    reachable but the credentials were rejected (the API answered
+    ``api_version()`` but ``host.get`` failed). Raises on connection /
+    TLS / DNS failures so the caller can show a red error.
+
+    Mirrors the two-step check the token path already runs: the green
+    status must mean "credentials work", not just "Zabbix answered".
+    """
+    from zabbix_utils import ZabbixAPI
+    api = ZabbixAPI(url=url, validate_certs=verify_ssl, skip_version_check=True)
+    # Raises on bad credentials as well as connection problems.
+    api.login(user=username, password=password)
+    version = str(api.api_version())
+    try:
+        api.host.get(limit=1, output=["hostid"])
+        return True, version
+    except Exception:
+        return False, version
+
+
 async def server_test(request: Request) -> Response:
     """Test connection to a specific Zabbix server (HTMX endpoint)."""
     admin_app = request.app.state.admin_app
@@ -503,26 +563,60 @@ async def server_test(request: Request) -> Response:
 
     from starlette.responses import HTMLResponse
     import html as _html
+
+    # Servers configured with username/password (Zabbix < 5.4) can't go
+    # through client_manager.check_connection, which always logs in with
+    # the API token. Read the *saved* config so we test exactly what will
+    # be loaded on restart; fall back to check_connection for
+    # token-authenticated servers.
+    saved = {}
     try:
-        result = await asyncio.to_thread(client_manager.check_connection, server_name)
-        version = _html.escape(client_manager.get_version(server_name))
-        if result.get("token_ok"):
+        doc = load_config_document(admin_app.config_path)
+        saved = dict(doc.get("zabbix", {}).get(server_name, {}) or {})
+    except Exception:
+        pass
+
+    if not saved.get("api_token"):
+        # No API token -> username/password login (Zabbix < 5.4).
+        try:
+            auth_ok, version = await asyncio.to_thread(
+                _probe_user_login,
+                saved.get("url", ""),
+                str(saved.get("username", "") or ""),
+                str(saved.get("password", "") or ""),
+                bool(saved.get("verify_ssl", True)),
+            )
+        except Exception as e:
+            msg = _html.escape(_friendly_error(e))
+            return HTMLResponse(
+                f'<span class="status-dot status-dot-red"></span> Error'
+                f'<span style="margin-left:8px; font-size:0.8em; color:var(--color-danger);">{msg}</span>'
+            )
+        if auth_ok:
             return HTMLResponse(
                 f'<span class="status-dot status-dot-green"></span> Connected'
-                f'<span style="margin-left:8px;">Zabbix {version}</span>'
+                f'<span style="margin-left:8px;">Zabbix {_html.escape(version)}</span>'
                 f'<span class="test-ok" style="margin-left:8px; color:var(--color-success); animation: fadeOut 2s forwards;">&#x2713;</span>'
             )
-        else:
-            return HTMLResponse(
-                f'<span class="status-dot status-dot-yellow"></span> API online'
-                f'<span style="margin-left:8px;">Zabbix {version}</span>'
-                f'<span style="margin-left:8px; font-size:0.8em; color:var(--color-warning);">&#x26A0; Token invalid or expired</span>'
-            )
-    except Exception as e:
-        msg = _html.escape(_friendly_error(e))
         return HTMLResponse(
-            f'<span class="status-dot status-dot-red"></span> Error'
-            f'<span style="margin-left:8px; font-size:0.8em; color:var(--color-danger);">{msg}</span>'
+            f'<span class="status-dot status-dot-yellow"></span> API online'
+            f'<span style="margin-left:8px;">Zabbix {_html.escape(version)}</span>'
+            f'<span style="margin-left:8px; font-size:0.8em; color:var(--color-warning);">&#x26A0; Invalid credentials</span>'
+        )
+
+    result = await asyncio.to_thread(client_manager.check_connection, server_name)
+    version = _html.escape(client_manager.get_version(server_name))
+    if result.get("token_ok"):
+        return HTMLResponse(
+            f'<span class="status-dot status-dot-green"></span> Connected'
+            f'<span style="margin-left:8px;">Zabbix {version}</span>'
+            f'<span class="test-ok" style="margin-left:8px; color:var(--color-success); animation: fadeOut 2s forwards;">&#x2713;</span>'
+        )
+    else:
+        return HTMLResponse(
+            f'<span class="status-dot status-dot-yellow"></span> API online'
+            f'<span style="margin-left:8px;">Zabbix {version}</span>'
+            f'<span style="margin-left:8px; font-size:0.8em; color:var(--color-warning);">&#x26A0; Invalid token or credentials</span>'
         )
 
 
@@ -586,6 +680,8 @@ async def server_test_new(request: Request) -> Response:
     form = await request.form()
     url = str(form.get("url", "")).strip()
     api_token = str(form.get("api_token", "")).strip()
+    username = str(form.get("username", "")).strip()
+    password = str(form.get("password", "")).strip()
     verify_ssl = form.get("verify_ssl") == "1"
 
     # SECURITY: validate URL scheme and block internal/private addresses (SSRF prevention)
@@ -649,13 +745,21 @@ async def server_test_new(request: Request) -> Response:
     except (socket.gaierror, ValueError):
         pass  # Let ZabbixAPI handle DNS errors
 
-    if not url or not api_token:
-        return HTMLResponse('<span class="text-danger">URL and API token are required</span>')
+    if not url:
+        return HTMLResponse('<span class="text-danger">URL is required</span>')
+
+    # Auth method: either an API token or a username/password pair
+    # (Zabbix < 5.4 has no API tokens). Mirrors _parse_zabbix_server.
+    if not api_token and (not username or not password):
+        return HTMLResponse('<span class="text-danger">Provide an API token, or a username and password pair</span>')
 
     try:
         from zabbix_utils import ZabbixAPI
         api = ZabbixAPI(url=url, validate_certs=verify_ssl, skip_version_check=True)
-        api.login(token=api_token)
+        if api_token:
+            api.login(token=api_token)
+        else:
+            api.login(user=username, password=password)
         version = _html.escape(str(api.api_version()))
     except Exception as e:
         msg = _html.escape(_friendly_error(e))
@@ -665,10 +769,10 @@ async def server_test_new(request: Request) -> Response:
         )
     # api_version() is unauthenticated - it only proves the URL
     # points at a Zabbix frontend. Hit an authenticated method too
-    # so the green status reflects "token works" not just "Zabbix
-    # answered". Reported 2026-04-27 with a video where the dialog
-    # said OK against a wrong api_token. Mirrors the same two-step
-    # check the live `/servers/<n>/test` endpoint already runs.
+    # so the green status reflects "credentials work" not just
+    # "Zabbix answered". Reported 2026-04-27 with a video where the
+    # dialog said OK against a wrong api_token. Mirrors the same
+    # two-step check the live `/servers/<n>/test` endpoint already runs.
     try:
         api.host.get(limit=1, output=["hostid"])
         return HTMLResponse(
@@ -678,5 +782,5 @@ async def server_test_new(request: Request) -> Response:
     except Exception:
         return HTMLResponse(
             f'<span class="status-dot status-dot-yellow"></span>'
-            f'<span style="color:var(--color-warning);"> API online (Zabbix {version}) but the API token was rejected. Check that the token has at least read permissions.</span>'
+            f'<span style="color:var(--color-warning);"> API online (Zabbix {version}) but the credentials were rejected. Check that the token or username/password has at least read permissions.</span>'
         )

--- a/src/zabbix_mcp/api/users.py
+++ b/src/zabbix_mcp/api/users.py
@@ -143,7 +143,8 @@ _USER_METHODS: list[MethodDef] = [
             "it can no longer be used for API calls. Good practice for cleanup "
             "after scripted workflows. Requires ``auth_sessionid`` to be set "
             "to the session id from a prior ``user.login`` call - the "
-            "configured server-level api_token cannot be used here because "
+            "configured server-level credentials (api_token or username/password) "
+            "cannot be used here because "
             "logging it out would break every subsequent call from this MCP."
         ),
         read_only=False,
@@ -151,8 +152,9 @@ _USER_METHODS: list[MethodDef] = [
             ParamDef(
                 "auth_sessionid", "str",
                 "Session id from a prior user.login call. The MCP wrapper "
-                "uses this for the auth field instead of the server-level "
-                "api_token, so invalidating it does not affect other tools.",
+                "uses this for the auth field instead of the configured "
+                "server credentials, so invalidating it does not affect "
+                "other tools.",
                 required=True,
             ),
         ],
@@ -164,7 +166,8 @@ _USER_METHODS: list[MethodDef] = [
             "Check whether a session is still valid. Returns the authenticated "
             "user's details if so. Requires ``auth_sessionid`` to be set to a "
             "session id (typically from a prior ``user.login``); the configured "
-            "server-level api_token cannot validate against the session table."
+            "server credentials (api_token or username/password) cannot "
+            "validate against the session table."
         ),
         read_only=True,
         params=[
@@ -380,7 +383,8 @@ _USERDIRECTORY_METHODS: list[MethodDef] = [
             "that Zabbix can connect to the directory server with the provided "
             "parameters and optionally performs a test authentication. Use this "
             "before creating or updating a directory to validate settings. "
-            "Authenticates with the configured server-level api_token by default; "
+            "Authenticates with the configured server-level credentials (api_token or "
+            "username/password) by default; "
             "set ``auth_sessionid`` to a session id from ``user.login`` if your "
             "Zabbix configuration restricts userdirectory.test to interactive "
             "sessions."
@@ -391,7 +395,7 @@ _USERDIRECTORY_METHODS: list[MethodDef] = [
                 "auth_sessionid", "str",
                 "Optional session id from a prior user.login call. When set, "
                 "the wrapper uses it for the JSON-RPC auth header instead of "
-                "the configured api_token.",
+                "the configured server credentials.",
             ),
             ParamDef(
                 "params", "dict",

--- a/src/zabbix_mcp/client.py
+++ b/src/zabbix_mcp/client.py
@@ -210,13 +210,24 @@ class ClientManager:
         # 300 s default matches Zabbix PHP frontend's max_execution_time
         # so expensive exports / long history.get ranges can complete.
         timeout = getattr(srv, "request_timeout", 300) or 300
+        # zabbix-utils only supports Zabbix >= 6.0 by default (its version
+        # gate is __min_supported__ = 6.0). When authenticating with
+        # username/password we may be talking to Zabbix 5.0-5.2 (which has
+        # no API tokens), so skip the version check. Token auth implies
+        # Zabbix 5.4+ and keeps the user-controlled skip_version_check.
+        skip_version_check = srv.skip_version_check or (not srv.api_token)
         api = ZabbixAPI(
             url=srv.url,
             ssl_context=_build_ssl_context(srv.verify_ssl),
-            skip_version_check=srv.skip_version_check,
+            skip_version_check=skip_version_check,
             timeout=timeout,
         )
-        api.login(token=srv.api_token)
+        if srv.api_token:
+            logger.info("Authenticating to '%s' using API token", name)
+            api.login(token=srv.api_token)
+        else:
+            logger.info("Authenticating to '%s' using user/password", name)
+            api.login(user=srv.username, password=srv.password)
 
         version = api.api_version()
         logger.info("Connected to '%s' - Zabbix %s", name, version)
@@ -375,7 +386,7 @@ class ClientManager:
         return obj(**params)
 
     def check_connection(self, server: str) -> dict:
-        """Verify connectivity and token auth to a Zabbix server.
+        """Verify connectivity and auth (API token or user/password) to a Zabbix server.
 
         Returns dict with 'api_ok' and 'token_ok' status.
         Raises on connection failure.

--- a/src/zabbix_mcp/config.py
+++ b/src/zabbix_mcp/config.py
@@ -47,6 +47,12 @@ class ZabbixServerConfig:
     read_only: bool = True
     verify_ssl: bool = True
     skip_version_check: bool = False
+    # Optional username + password for Zabbix < 5.4 (API tokens only
+    # exist from 5.4 onward). When `api_token` is set it takes
+    # precedence; these may coexist so ``graph_render`` can still log
+    # in to the frontend.
+    username: str = ""
+    password: str = ""
     # Optional username + password used by ``graph_render`` to acquire
     # a Zabbix frontend session cookie when the API token alone is
     # rejected by ``/chart2.php`` (Zabbix 6.0+ frontend uses signed
@@ -380,18 +386,31 @@ def _parse_zabbix_server(name: str, srv: object) -> "ZabbixServerConfig":
             f"IPv4/IPv6 address."
         )
     api_token = srv.get("api_token")
-    if not api_token:
-        raise ConfigError(f"Zabbix server '{name}' is missing 'api_token'")
-    api_token = _resolve_env_vars(api_token)
-    if not api_token.strip():
-        raise ConfigError(
-            f"Zabbix server '{name}' has empty 'api_token' after resolving "
-            f"environment variables"
-        )
+    username = str(srv.get("username", "") or "")
+    password = str(srv.get("password", "") or "")
+    if api_token:
+        # API token takes precedence when present.
+        api_token = _resolve_env_vars(api_token)
+        if not api_token.strip():
+            raise ConfigError(
+                f"Zabbix server '{name}' has empty 'api_token' after resolving "
+                f"environment variables"
+            )
+    else:
+        # Zabbix < 5.4 has no API tokens: fall back to user.login.
+        if not username or not password:
+            raise ConfigError(
+                f"Zabbix server '{name}' is missing 'api_token' (Zabbix < 5.4) "
+                f"or 'username'/'password'"
+            )
+    username = _resolve_env_vars(username)
+    password = _resolve_env_vars(password)
     return ZabbixServerConfig(
         name=name,
         url=url.rstrip("/"),
         api_token=api_token,
+        username=username,
+        password=password,
         read_only=srv.get("read_only", True),
         verify_ssl=srv.get("verify_ssl", True),
         skip_version_check=srv.get("skip_version_check", False),

--- a/src/zabbix_mcp/server.py
+++ b/src/zabbix_mcp/server.py
@@ -1537,9 +1537,10 @@ def _make_tool_handler(
         # session (user.logout, user.checkAuthentication,
         # userdirectory.test) accept an ``auth_sessionid`` parameter
         # that the wrapper uses for the JSON-RPC ``auth`` field
-        # instead of the configured api_token. Lets the caller log in
-        # via user.login first, then exercise these tools without
-        # invalidating the long-lived MCP api_token.
+        # instead of the configured server credentials (api_token or
+        # username/password). Lets the caller log in via user.login
+        # first, then exercise these tools without invalidating the
+        # long-lived MCP server auth session.
         # Only the three session-scoped methods are allowed to consume
         # ``auth_sessionid``. Any other tool that receives the kwarg
         # gets it silently dropped so a caller cannot reroute (say)

--- a/tests/test_user_password_auth.py
+++ b/tests/test_user_password_auth.py
@@ -1,0 +1,207 @@
+#
+# Zabbix MCP Server
+# Copyright (C) 2026 initMAX s.r.o.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Auth by user/password (user.login) for Zabbix < 5.4.
+
+API tokens only exist from Zabbix 5.4 onward. A [zabbix.<name>] section
+may omit ``api_token`` and authenticate with ``username``/``password``
+instead. When both are present, ``api_token`` takes precedence.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from zabbix_mcp.config import AppConfig, ConfigError, ZabbixServerConfig, load_config
+from zabbix_mcp.client import ClientManager
+
+
+def _load_toml(body: str) -> "AppConfig":
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write(body)
+        f.flush()
+        path = f.name
+    try:
+        return load_config(path)
+    finally:
+        os.unlink(path)
+
+
+def _write_toml(body: str) -> str:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write(body)
+        f.flush()
+        return f.name
+
+
+class TestConfigUserPasswordAuth(unittest.TestCase):
+    """load_config must accept username/password in place of api_token."""
+
+    def test_username_password_without_api_token_is_valid(self):
+        cfg = _load_toml(
+            '[zabbix.prod]\n'
+            'url = "http://zabbix.example.com"\n'
+            'username = "admin"\n'
+            'password = "secret"\n'
+        )
+        srv = cfg.zabbix_servers["prod"]
+        self.assertFalse(srv.api_token)
+        self.assertEqual(srv.username, "admin")
+        self.assertEqual(srv.password, "secret")
+
+    def test_missing_api_token_and_credentials_raises(self):
+        path = _write_toml(
+            '[zabbix.prod]\n'
+            'url = "http://zabbix.example.com"\n'
+        )
+        try:
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(path)
+            msg = str(ctx.exception)
+            self.assertIn("api_token", msg)
+            self.assertIn("username", msg)
+            self.assertIn("password", msg)
+        finally:
+            os.unlink(path)
+
+    def test_only_username_missing_password_raises(self):
+        path = _write_toml(
+            '[zabbix.prod]\n'
+            'url = "http://zabbix.example.com"\n'
+            'username = "admin"\n'
+        )
+        try:
+            with self.assertRaises(ConfigError):
+                load_config(path)
+        finally:
+            os.unlink(path)
+
+    def test_only_password_missing_username_raises(self):
+        path = _write_toml(
+            '[zabbix.prod]\n'
+            'url = "http://zabbix.example.com"\n'
+            'password = "secret"\n'
+        )
+        try:
+            with self.assertRaises(ConfigError):
+                load_config(path)
+        finally:
+            os.unlink(path)
+
+    def test_api_token_still_valid(self):
+        cfg = _load_toml(
+            '[zabbix.prod]\n'
+            'url = "http://zabbix.example.com"\n'
+            'api_token = "tok"\n'
+        )
+        self.assertEqual(cfg.zabbix_servers["prod"].api_token, "tok")
+
+    def test_api_token_takes_precedence_over_credentials(self):
+        cfg = _load_toml(
+            '[zabbix.prod]\n'
+            'url = "http://zabbix.example.com"\n'
+            'api_token = "tok"\n'
+            'username = "admin"\n'
+            'password = "secret"\n'
+        )
+        srv = cfg.zabbix_servers["prod"]
+        self.assertEqual(srv.api_token, "tok")
+        self.assertEqual(srv.username, "admin")
+        self.assertEqual(srv.password, "secret")
+
+    def test_credentials_resolve_env_vars(self):
+        os.environ["_ZABBIX_TEST_USER"] = "admin"
+        os.environ["_ZABBIX_TEST_PASS"] = "s3cr3t"
+        try:
+            cfg = _load_toml(
+                '[zabbix.prod]\n'
+                'url = "http://zabbix.example.com"\n'
+                'username = "${_ZABBIX_TEST_USER}"\n'
+                'password = "${_ZABBIX_TEST_PASS}"\n'
+            )
+        finally:
+            del os.environ["_ZABBIX_TEST_USER"]
+            del os.environ["_ZABBIX_TEST_PASS"]
+        srv = cfg.zabbix_servers["prod"]
+        self.assertEqual(srv.username, "admin")
+        self.assertEqual(srv.password, "s3cr3t")
+
+    def test_missing_env_var_in_password_raises(self):
+        path = _write_toml(
+            '[zabbix.prod]\n'
+            'url = "http://zabbix.example.com"\n'
+            'username = "admin"\n'
+            'password = "${_NONEXISTENT_ZABBIX_PASS}"\n'
+        )
+        try:
+            with self.assertRaises(ConfigError):
+                load_config(path)
+        finally:
+            os.unlink(path)
+
+
+class TestClientConnectAuth(unittest.TestCase):
+    """ClientManager._connect must pick the right login flavour."""
+
+    def _manager(self, api_token: str = "", username: str = "admin", password: str = "secret") -> ClientManager:
+        srv = ZabbixServerConfig(
+            name="test",
+            url="http://zabbix.example.com",
+            api_token=api_token,
+            username=username,
+            password=password,
+        )
+        return ClientManager(AppConfig(zabbix_servers={"test": srv}))
+
+    def test_connect_logins_with_user_password_when_no_token(self):
+        mgr = self._manager(api_token="")
+        with patch("zabbix_mcp.client.ZabbixAPI") as mock_cls:
+            instance = mock_cls.return_value
+            instance.api_version.return_value = "5.0.0"
+            mgr._connect("test")
+            instance.login.assert_called_once_with(user="admin", password="secret")
+
+    def test_connect_logins_with_token_when_present(self):
+        mgr = self._manager(api_token="tok")
+        with patch("zabbix_mcp.client.ZabbixAPI") as mock_cls:
+            instance = mock_cls.return_value
+            instance.api_version.return_value = "6.0.0"
+            mgr._connect("test")
+            instance.login.assert_called_once_with(token="tok")
+
+    def test_connect_token_precedence_over_credentials(self):
+        mgr = self._manager(api_token="tok", username="admin", password="secret")
+        with patch("zabbix_mcp.client.ZabbixAPI") as mock_cls:
+            instance = mock_cls.return_value
+            instance.api_version.return_value = "6.0.0"
+            mgr._connect("test")
+            instance.login.assert_called_once_with(token="tok")
+
+    def test_connect_calls_api_version_after_login(self):
+        mgr = self._manager(api_token="")
+        with patch("zabbix_mcp.client.ZabbixAPI") as mock_cls:
+            instance = mock_cls.return_value
+            instance.api_version.return_value = "5.0.0"
+            client = mgr._connect("test")
+            self.assertIs(client, instance)
+            instance.login.assert_called_once()
+            instance.api_version.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Zabbix only supports API tokens from **5.4** onward. On Zabbix **5.0-5.2**
there is no API token feature, so this PR lets `[zabbix.<name>]` authenticate
with `username`/`password` via `user.login` instead of requiring `api_token`.

Fixes #77

## Changes

- **config.py** - `ZabbixServerConfig` gains `username`/`password`. Either
  `api_token` OR the credential pair is now required; when both are set,
  `api_token` takes precedence. Both support `${ENV_VAR}` expansion, so the
  password can live in an environment variable (e.g. `.env` referenced by
  `docker compose` `env_file`) instead of plaintext in `config.toml`.
- **client.py** - `_connect` calls `api.login(user=, password=)` when no
  token is set. Also auto-enables `skip_version_check` for credential auth,
  because `zabbix-utils` gates on `__min_supported__ = 6.0` and would
  otherwise reject Zabbix 5.0 at startup.
- **admin portal** - `/servers` create, edit and test-connection flows now
  expose Username/Password fields. Edit preserves "leave empty to keep"
  semantics already used for `api_token`/`frontend_password`.
- **docs** - README, `config.example.toml` and INSTALL document the
  Zabbix 5.0-5.2 username/password path and keeping secrets in env vars.
- **tests** - new `tests/test_user_password_auth.py` (12 tests) covering
  config validation and the client login flavour.

## Testing

- `pytest` suite: 439 collected, 12 new tests pass.
- The 9 remaining failures are pre-existing and Windows-only
  (`os.O_NOFOLLOW`, file-mode checks) - unrelated to this change.
- Manually verified against a real Zabbix **5.0.47** instance using
  username/password auth.

## Compatibility

- Backward compatible: existing `api_token`-only configs behave exactly as
  before (token path is unchanged).
- Secret handling: passwords may be referenced via `${ENV_VAR}` so they are
  never stored in the config file - for Docker, `.env` is injected into the
  container via `env_file` and can hold the Zabbix password instead.